### PR TITLE
Disallow gzip

### DIFF
--- a/lib/morph-cli.rb
+++ b/lib/morph-cli.rb
@@ -24,6 +24,7 @@ module MorphCLI
       end
     end
     result = RestClient::Request.execute(:method => :post, :url => "#{env_config[:base_url]}/run",
+      :headers => {:accept_encoding => 'identity'},
       :payload => {:api_key => env_config[:api_key], :code => file}, :block_response => block)
   end
 


### PR DESCRIPTION
Buggy ruby can't grok it:

[x@localhost scraper-sk_company_register]$ morph
Uploading and running...
/usr/share/gems/gems/json-1.7.7/lib/json/common.rb:155:in `parse': 757: unexpected token at '' (JSON::ParserError)
    from /usr/share/gems/gems/json-1.7.7/lib/json/common.rb:155:in `parse'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:32:in `log'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:15:in `block (3 levels) in execute'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:14:in `each'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:14:in `block (2 levels) in execute'
    from /usr/share/ruby/net/protocol.rb:407:in `call_block'
    from /usr/share/ruby/net/protocol.rb:398:in `<<'
    from /usr/share/ruby/net/protocol.rb:106:in `read'
    from /usr/share/ruby/net/http/response.rb:313:in `read_chunked'
    from /usr/share/ruby/net/http/response.rb:276:in `block in read_body_0'
    from /usr/share/ruby/net/http/response.rb:250:in `inflater'
    from /usr/share/ruby/net/http/response.rb:274:in `read_body_0'
    from /usr/share/ruby/net/http/response.rb:201:in `read_body'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:11:in `block in execute'
    from /usr/share/ruby/net/http.rb:1413:in `block (2 levels) in transport_request'
    from /usr/share/ruby/net/http/response.rb:162:in `reading_body'
    from /usr/share/ruby/net/http.rb:1412:in `block in transport_request'
    from /usr/share/ruby/net/http.rb:1403:in `catch'
    from /usr/share/ruby/net/http.rb:1403:in `transport_request'
    from /usr/share/ruby/net/http.rb:1376:in `request'
    from /usr/share/gems/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
    from /usr/share/gems/gems/rest-client-1.6.7/lib/restclient/request.rb:178:in `block in transmit'
    from /usr/share/ruby/net/http.rb:852:in `start'
    from /usr/share/gems/gems/rest-client-1.6.7/lib/restclient/request.rb:176:in `transmit'
    from /usr/share/gems/gems/rest-client-1.6.7/lib/restclient/request.rb:65:in `execute'
    from /usr/share/gems/gems/rest-client-1.6.7/lib/restclient/request.rb:34:in `execute'
    from /usr/share/gems/gems/morph-cli-0.2.1/lib/morph-cli.rb:26:in `execute'
    from /usr/share/gems/gems/morph-cli-0.2.1/bin/morph:32:in `execute'
    from /usr/share/gems/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /usr/share/gems/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /usr/share/gems/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /usr/share/gems/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /usr/share/gems/gems/morph-cli-0.2.1/bin/morph:63:in `<top (required)>'
    from /usr/bin/morph:23:in `load'
    from /usr/bin/morph:23:in `<main>'