### PR TITLE
Increase restclient execute timeout to 10 minutes

### DIFF
--- a/lib/morph-cli.rb
+++ b/lib/morph-cli.rb
@@ -23,8 +23,16 @@ module MorphCLI
         exit(1)
       end
     end
+    if env_config.key?(:timeout)
+      timeout = env_config[:timeout]
+    else
+      timeout = 600 # 10 minutes should be "enough for everyone", right?
+                    # Setting to nil will disable the timeout entirely.
+                    # Default is 60 seconds.
+    end
     result = RestClient::Request.execute(:method => :post, :url => "#{env_config[:base_url]}/run",
-      :payload => {:api_key => env_config[:api_key], :code => file}, :block_response => block)
+      :payload => {:api_key => env_config[:api_key], :code => file}, :block_response => block,
+      :timeout => timeout)
   end
 
   def self.log(line)


### PR DESCRIPTION
Hello,  

Below is a problem I tripped over while a python scraper was trying to pull down and install (amongst other things) [lxml](http://lxml.de/index.html), from its requirements.txt.

lxml took a bit over a minute to compile & install on the remote host, so nothing echoed back on the terminal for that amount of time, and the morph-cli session was terminated before anything further happened.

This is actually my first tiny foray into ruby, so if it looks un-rubyish or you'd prefer things done differently, please throw change requests back to me as you'd like.  

## Overview

The default timeout, if there's no console activity, is 60 seconds.
If a scraper has several dependencies to compile & install (buildpacks...),
it's not too difficult to hit this limit.

In these cases, the morph-cli run would die with something like the
following:

```
/var/lib/gems/2.1.0/gems/rest-client-1.8.0/lib/restclient/request.rb:427:in `rescue in transmit': Request Timeout (RestClient::RequestTimeout)
    from /var/lib/gems/2.1.0/gems/rest-client-1.8.0/lib/restclient/request.rb:350:in `transmit'
    from /var/lib/gems/2.1.0/gems/rest-client-1.8.0/lib/restclient/request.rb:176:in `execute'
    from /var/lib/gems/2.1.0/gems/rest-client-1.8.0/lib/restclient/request.rb:41:in `execute'
    from /var/lib/gems/2.1.0/gems/morph-cli-0.2.2/lib/morph-cli.rb:26:in `execute'
    from /var/lib/gems/2.1.0/gems/morph-cli-0.2.2/bin/morph:32:in `execute'
    from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /var/lib/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /var/lib/gems/2.1.0/gems/morph-cli-0.2.2/bin/morph:63:in `<top (required)>'
    from /usr/local/bin/morph:23:in `load'
    from /usr/local/bin/morph:23:in `<main>'
```

This change sets the default timeout to 600 seconds, but will read a
config value (":timeout:") to override this as desired.