### PR TITLE
add missing require statement

### DIFF
--- a/lib/morph-cli.rb
+++ b/lib/morph-cli.rb
@@ -1,5 +1,6 @@
 require "morph-cli/version"
 require 'yaml'
+require 'find'
 
 module MorphCLI
   def self.execute(directory, development, env_config)


### PR DESCRIPTION
As noted in https://help.morph.io/t/error-using-morph-cli/376 `morph-cli` has started thowing

```
morph-cli.rb:100:in `all_paths': uninitialized constant MorphCLI::Find (NameError)
```

for some users.

I _think_ what has happened here is that version 0.5.x of `archive-tar-minitar` pulled in `find` so running `require 'archive/tar/minitar'` [here](https://github.com/openaustralia/morph-cli/blob/master/bin/morph#L8) with that version of the dependency was implicitly requiring `find`.

If you upgrade to 0.6.x of `archive-tar-minitar` (or do a clean install of `morph-cli` which pulls in the latest dependency), calling `require 'archive/tar/minitar'` doesn't implicitly `require 'find'` anymore, causing that error.

Making the dependency explicit here should fix it, I think.