### PR TITLE
Fix CI workflow triggers to match default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/morph-cli.png)](http://badge.fury.io/rb/morph-cli)
-[![CI](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml)
 
 # Morph Commandline
 


### PR DESCRIPTION
## Description

Fixes the CI workflow triggers in `.github/workflows/ci.yml`. The workflow was configured to run on pushes and pull requests targeting `master`, but this repository's default branch is `main`, so CI never ran. It now runs on pushes to `main` and on all pull requests (no base-branch filter, so stacked pull requests also get checks). Also points the README CI badge at the `main` branch so it reflects real status.

## Motivation and Context

CI added in #15 has never actually executed because of the branch name mismatch — every PR and push has silently skipped checks. This is the smallest possible fix and is a prerequisite for the follow-up modernisation PRs, which rely on CI feedback.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Workflow-only change: verified by the CI run on this very pull request (previously no runs triggered at all).

## Screenshots (if appropriate):

N/A

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Part 1 of a 5-PR modernisation series (merge order: this one first).

Assisted-by: opencode/anthropic.claude-fable-5
