### PR TITLE
Fill in gem metadata and refresh README

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Gemspec/RequireMFA:
-  Exclude:
-    - 'morph-cli.gemspec'
-
 # Offense count: 8
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Require Ruby 3.3 or later (was Ruby 2.7)
+- Replace unmaintained `rest-client` with `faraday` + `faraday-multipart`
+- Replace unmaintained `archive-tar-minitar` with `minitar` 1.x
+- Write the upload tarball to a temporary file instead of the shared `/tmp/out` path
+- Load `~/.morph` config with safe YAML loading
+- Fill in gem metadata: homepage, source code, bug tracker and changelog URIs; require
+  MFA for manual pushes to RubyGems
+
+### Added
+
+- SimpleCov coverage reporting and a much expanded test suite (CLI and HTTP behaviour
+  tested with WebMock, no network access in tests)
+
+## [0.2.5] and earlier
+
+No changelog was kept for releases up to and including 0.2.5. See the
+[commit history](https://github.com/openaustralia/morph-cli/commits/main) for details.
+
+[Unreleased]: https://github.com/openaustralia/morph-cli/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/openaustralia/morph-cli/releases/tag/v0.2.5

--- a/README.md
+++ b/README.md
@@ -1,41 +1,67 @@
-[![Gem Version](https://badge.fury.io/rb/morph-cli.png)](http://badge.fury.io/rb/morph-cli)
+[![Gem Version](https://img.shields.io/gem/v/morph-cli)](https://rubygems.org/gems/morph-cli)
 [![CI](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openaustralia/morph-cli/actions/workflows/ci.yml)
 
-# Morph Commandline
+# Morph CLI
 
-Runs Morph scrapers from the commandline.
+Runs [morph.io](https://morph.io) scrapers from the command line.
 
-Actually it will run them on the Morph server identically to the real thing. That means not installing a bucket load of libraries
-and bits and bobs that are already installed with the Morph scraper environments.
+Actually it will run them on the morph.io server identically to the real thing.
+That means not installing a bucket load of libraries and bits and bobs that are
+already installed with the morph.io scraper environments.
 
-To run a scraper in your local directory
+## Installation
+
+You'll need Ruby 3.3 or later. Then
+
+    gem install morph-cli
+
+## Usage
+
+To run the scraper in your current directory
 
     morph
 
 Yup, that's it.
 
-It runs the code that's there right now. It doesn't need to be checked into git or anything.
+It runs the code that's there right now. It doesn't need to be checked into git
+or anything.
+
+The first time you run it, it will ask for your morph.io API key, which it
+saves in `~/.morph`.
 
 For help
 
     morph help
 
-## Installation
-
-You'll need Ruby >= 1.9 and then
-
-    gem install morph-cli
-
 ## Limitations
 
-It uploads your code everytime. So if it's big it might take a little while. Scrapers are not usually so I'm hoping this won't really be an issue
+It uploads your code every time. So if it's big it might take a little while.
+Scrapers are not usually so I'm hoping this won't really be an issue.
 
-It doesn't yet return you the resulting sqlite database (or use the one you might have locally)
+It doesn't yet return you the resulting sqlite database (or use the one you
+might have locally).
+
+## Development
+
+After checking out the repo, run `bundle install` to install dependencies.
+Then run the tests with
+
+    bundle exec rspec
 
 ## Contributing
 
+Contributions are welcome! Please see the
+[OpenAustralia Foundation contributing guide](https://github.com/openaustralia/.github/blob/main/.github/CONTRIBUTING.md)
+for how we work: GitHub Flow, draft pull requests, signed-off commits (DCO)
+and our contributor licence agreement.
+
 1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+2. Create your feature branch (`git checkout -b feature/my-new-feature`)
+3. Commit your changes (`git commit -s -am 'Add some feature'`)
+4. Push to the branch (`git push origin feature/my-new-feature`)
+5. Create a new pull request
+
+## License
+
+The gem is available as open source under the terms of the
+[MIT License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ already installed with the morph.io scraper environments.
 
 ## Installation
 
-You'll need Ruby 3.3 or later. Then
+You'll need Ruby 3.2 or later. Then
 
     gem install morph-cli
 

--- a/morph-cli.gemspec
+++ b/morph-cli.gemspec
@@ -7,12 +7,22 @@ Gem::Specification.new do |spec|
   spec.version       = MorphCLI::VERSION
   spec.authors       = ["Matthew Landauer"]
   spec.email         = ["matthew@oaf.org.au"]
-  spec.description   = "Command line interface for Morph"
-  spec.summary       = "Command line interface for Morph"
-  spec.homepage      = ""
+  spec.summary       = "Run morph.io scrapers from the command line"
+  spec.description   = "Command line interface for morph.io. Uploads the scraper in the " \
+                       "current directory to a morph.io server, runs it there and streams " \
+                       "the output back to your terminal."
+  spec.homepage      = "https://github.com/openaustralia/morph-cli"
   spec.license       = "MIT"
 
   spec.required_ruby_version = ">= 3.2"
+
+  spec.metadata = {
+    "homepage_uri" => "https://github.com/openaustralia/morph-cli",
+    "source_code_uri" => "https://github.com/openaustralia/morph-cli",
+    "bug_tracker_uri" => "https://github.com/openaustralia/morph-cli/issues",
+    "changelog_uri" => "https://github.com/openaustralia/morph-cli/blob/main/CHANGELOG.md",
+    "rubygems_mfa_required" => "true"
+  }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = %w[morph]


### PR DESCRIPTION
## Description

Fixes the gem's metadata and documentation:

- **Homepage** — currently empty on rubygems.org — set to this repository, plus `homepage_uri`, `source_code_uri`, `bug_tracker_uri` and `changelog_uri` metadata
- `rubygems_mfa_required = "true"` so manual pushes to RubyGems require MFA (the matching RuboCop todo exclusion is removed)
- Accurate summary and description mentioning morph.io and what the CLI actually does
- New `CHANGELOG.md` in Keep a Changelog format, covering the unreleased modernisation work and linked from the gem metadata
- README rewritten: working gem-version and CI badges, accurate supported Ruby (>= 3.2, replacing "Ruby >= 1.9"), install/usage docs including where the API key is stored, development instructions, contributing section linking the [OAF contributing guide](https://github.com/openaustralia/.github/blob/main/.github/CONTRIBUTING.md), and a license section

## Motivation and Context

The rubygems.org listing for morph-cli has no homepage or source link, making the gem hard to trace back to this repo, and the README claimed Ruby 1.9 support. Part 4 of the modernisation series.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

`bundle exec rake build` then inspected the built gem with `gem spec` to confirm homepage and metadata are set; `bundle exec rspec` (29 examples, 0 failures) and `bundle exec rubocop` (no offenses) on Ruby 3.2.2.

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

Part 4 of the 5-PR modernisation series. Stacked on #19 (base branch `chore/increase-test-coverage`); GitHub will retarget as the stack merges.

Assisted-by: opencode/anthropic.claude-fable-5

