### PR TITLE
Compress uploaded code with gzip

### DIFF
--- a/lib/morph-cli.rb
+++ b/lib/morph-cli.rb
@@ -6,6 +6,7 @@ require 'pathname'
 require 'tempfile'
 require 'fileutils'
 require 'filesize'
+require 'zlib'
 require 'faraday'
 require 'faraday/multipart'
 require 'minitar'
@@ -42,7 +43,7 @@ module MorphCLI
     connection.post("/run") do |req|
       req.body = {
         api_key: env_config[:api_key],
-        code: Faraday::Multipart::FilePart.new(file, "application/octet-stream")
+        code: Faraday::Multipart::FilePart.new(file, "application/gzip")
       }
       req.options.timeout = timeout
       req.options.on_data = proc do |chunk, _overall_received_bytes, env|
@@ -106,21 +107,22 @@ module MorphCLI
     FileUtils.cd(cwd)
   end
 
-  # Packs the given paths (relative to directory) into a tar file and returns
-  # an open, rewound file handle ready for upload.
+  # Packs the given paths (relative to directory) into a gzip-compressed tar
+  # file and returns an open, rewound file handle ready for upload.
   def self.create_tar(directory, paths)
-    tempfile = Tempfile.new(["morph", ".tar"])
+    tempfile = Tempfile.new(["morph", ".tar.gz"])
     tempfile.binmode
 
     in_directory(directory) do
-      output = Minitar::Output.new(tempfile)
-      paths.each do |entry|
-        Minitar.pack_file(entry, output)
-      end
+      gzip = Zlib::GzipWriter.new(tempfile)
+      output = Minitar::Output.new(gzip)
+      paths.each { |entry| Minitar.pack_file(entry, output) }
     ensure
-      # Writes the tar trailer and flushes without closing the underlying
-      # tempfile, so the returned handle stays open for reading.
+      # Closing the tar writer writes the tar trailer; finishing (not
+      # closing) the gzip stream writes the gzip trailer, leaving the
+      # underlying tempfile handle open for reading.
       output&.tar&.close
+      gzip&.finish
     end
 
     tempfile.flush

--- a/spec/morph_cli_spec.rb
+++ b/spec/morph_cli_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MorphCLI do
       end
     end
 
-    it "posts the API key and the code as multipart form data" do
+    it "posts the API key and the gzipped code as multipart form data" do
       stub_request(:post, "https://morph.io/run").to_return(status: 200, body: "")
 
       with_scraper_directory do |dir|
@@ -41,7 +41,7 @@ RSpec.describe MorphCLI do
       expect(WebMock).to(have_requested(:post, "https://morph.io/run").with do |req|
         req.headers["Content-Type"].start_with?("multipart/form-data") &&
           req.body.include?("secret-key") &&
-          req.body.include?("scraper.rb")
+          req.body.b.include?("\x1f\x8b".b) # gzip magic bytes
       end)
     end
 
@@ -122,7 +122,7 @@ RSpec.describe MorphCLI do
   end
 
   describe ".create_tar" do
-    it "packs the given paths into a readable tar" do
+    it "packs the given paths into a readable gzip-compressed tar" do
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, "scraper.rb"), "puts 'hi'\n")
         FileUtils.mkdir_p(File.join(dir, "lib"))
@@ -132,10 +132,22 @@ RSpec.describe MorphCLI do
         tar = described_class.create_tar(dir, paths)
 
         names = []
-        Minitar::Input.open(tar.path) do |input|
-          input.each { |entry| names << entry.full_name }
+        Zlib::GzipReader.open(tar.path) do |gzip|
+          Minitar::Input.open(gzip) do |input|
+            input.each { |entry| names << entry.full_name }
+          end
         end
         expect(names).to contain_exactly("scraper.rb", "lib/helper.rb")
+      end
+    end
+
+    it "compresses the tar" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "scraper.rb"), "a" * 100_000)
+
+        tar = described_class.create_tar(dir, described_class.all_paths(dir))
+
+        expect(File.size(tar.path)).to be < 100_000
       end
     end
 
@@ -147,7 +159,7 @@ RSpec.describe MorphCLI do
 
         expect(tar).not_to be_closed
         expect(tar.pos).to eq(0)
-        expect(tar.read).to include("scraper.rb")
+        expect(tar.read(2)).to eq("\x1f\x8b".b) # gzip magic bytes
       end
     end
   end


### PR DESCRIPTION
## Description

The `morph` command now gzip-compresses the tar of scraper code before uploading it. `MorphCLI.create_tar` wraps the tempfile in a `Zlib::GzipWriter` around the existing Minitar output, producing a `.tar.gz` instead of a plain `.tar`. The gzip stream is finished (not closed) so the returned tempfile handle stays open and rewound for the upload, preserving the method's existing contract, and the multipart content type is now `application/gzip`.

## Motivation and Context

Scraper code was uploaded as an uncompressed tar, wasting bandwidth and upload time. Text-heavy scraper directories compress very well, so this is a cheap win, especially on slow connections.

Resolves #1

**Heads up:** this needs a matching server-side change (openaustralia/morph#1519) before release. morph.io's `ApiController#run_remote` currently unpacks the upload with `Archive::Tar::Minitar.unpack` on a plain tar, so the server needs to decompress (or detect gzip) first. A CLI release before that lands would break `morph` against production.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Test-first: added specs asserting the archive is gzip-compressed (magic bytes, size reduction on compressible input, and readable via `Zlib::GzipReader` + `Minitar::Input`), confirmed they failed against the old implementation, then implemented the change and confirmed the full suite passes (`bundle exec rspec`, 30 examples, 0 failures, 97.6% line coverage). `bundle exec rubocop` is clean. Not yet run end-to-end against a server, since morph.io doesn't accept gzipped uploads yet (see above).

## Screenshots (if appropriate):

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI assistance

Written with AI assistance (`Assisted-by: OpenCode:anthropic.claude-fable-5`), reviewed by a human before submission.
